### PR TITLE
Specify tag for ubuntu image and apt update before install. Update hiawatha location

### DIFF
--- a/hiawatha/Dockerfile
+++ b/hiawatha/Dockerfile
@@ -1,12 +1,12 @@
 # Set the base image to Ubuntu
-FROM ubuntu
+FROM ubuntu:14.04
 
 # File Author / Maintainer
 MAINTAINER Quinton Marchi
 
 # Install Hiawatha
-RUN apt-get install libxslt1.1 wget -y
-RUN wget https://files.tuxhelp.org/hiawatha/hiawatha_9.13_amd64.deb && dpkg -i hiawatha_9.13_amd64.deb
+RUN apt-get update && apt-get install libxslt1.1 wget -y
+RUN wget https://mirror.tuxhelp.org/debian/pool/main/h/hiawatha/hiawatha_9.13_amd64.deb && dpkg -i hiawatha_9.13_amd64.deb
 
 # Remove the default Hiawatha configuration file
 RUN rm -v /etc/hiawatha/hiawatha.conf

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM    ubuntu
+FROM    ubuntu:14.04
 
 # File Author / Maintainer
 MAINTAINER emoose


### PR DESCRIPTION
The default latest tag was causing the image to fail to build due to not having sudo installed. An apt-get update is also needed to be run before the install otherwise the package is not found. A different mirror for hiawatha 9.13 also needs to be used as the previous path no longer hosts 9.x.